### PR TITLE
Add Event Page

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,23 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
+  "short_name": "EGG Web",
+  "name": "EGG Management Web App",
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
-import React            from 'react';
-import Header           from './components/Header';
-import ContentContainer from './components/ContentContainer';
-import Footer           from './components/Footer';
+import React, {useState}  from 'react';
+import Header             from './components/Header';
+import ContentContainer   from './components/ContentContainer';
+import Footer             from './components/Footer';
 import './App.css';
 
 function App() {

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, {useState}  from 'react';
+import React  from 'react';
 import Header             from './components/Header';
 import ContentContainer   from './components/ContentContainer';
 import Footer             from './components/Footer';

--- a/src/components/ContentContainer.js
+++ b/src/components/ContentContainer.js
@@ -4,7 +4,7 @@ import Events from './Events';
 function ContentContainer(){
     return (
         <div className="flex flex-wrap justify-center gap-y-8 py-8 mt-14 bg-[#18191b] min-h-[960px]">
-            <Events />
+            <Home />
         </div>
     );
 }

--- a/src/components/ContentContainer.js
+++ b/src/components/ContentContainer.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import HighlightEvent from './HighlightEvent';
 import HumansOfEgg from './HumansOfEgg';
+import Events from './Events';
 
 function ContentContainer(){
     return (
-        <div className="flex flex-col items-center gap-5 p-5 bg-[#18191b]">
-            <HighlightEvent />
-            <HumansOfEgg />
+        <div className="flex flex-col items-center p-5 bg-[#18191b] min-h-[960px]">
+            {/* <HighlightEvent />
+            <HumansOfEgg /> */}
+            <Events />
         </div>
     );
 }

--- a/src/components/ContentContainer.js
+++ b/src/components/ContentContainer.js
@@ -1,13 +1,9 @@
 import React from 'react';
-import HighlightEvent from './HighlightEvent';
-import HumansOfEgg from './HumansOfEgg';
 import Events from './Events';
 
 function ContentContainer(){
     return (
-        <div className="flex flex-col items-center p-5 bg-[#18191b] min-h-[960px]">
-            {/* <HighlightEvent />
-            <HumansOfEgg /> */}
+        <div className="flex flex-wrap justify-center gap-y-8 py-8 mt-14 bg-[#18191b] min-h-[960px]">
             <Events />
         </div>
     );

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -1,14 +1,15 @@
 import React from "react";
 
-function EventCard( { title, bgImg, time } ){
+function EventCard( { event } ){
     return (
-        <div className="inline-block w-64 h-80 shadow-xl bg-white">
+        <div className="inline-block w-64 h-80 shadow-md shadow-slate-400 bg-stone-400 hover:cursor-pointer">
             <div className="h-56 p-2">
-                <div>{title}</div>
-                <img src={bgImg} alt={title} className="brightness-75 contrast-125" />
+                <div>{event.title}</div>
+                <img src={event.imgUrl} alt={event.title} className="brightness-75 contrast-125" />
             </div>
             <div className="h-24 p-2">
-
+                <div>{event.time}</div>
+                <div>{event.date}</div>
             </div>
         </div>
     );

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+function EventCard( { title, bgImg, time } ){
+    return (
+        <div className="inline-block w-72 h-80 shadow-xl bg-[#242527]">
+            <div className="h-56 p-2">
+                <div>{title}</div>
+                <img src={bgImg} alt={title} className="brightness-75 contrast-125" />
+            </div>
+            <div className="h-24 p-2">
+
+            </div>
+        </div>
+    );
+}
+
+export default EventCard;

--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -2,7 +2,7 @@ import React from "react";
 
 function EventCard( { title, bgImg, time } ){
     return (
-        <div className="inline-block w-72 h-80 shadow-xl bg-[#242527]">
+        <div className="inline-block w-64 h-80 shadow-xl bg-white">
             <div className="h-56 p-2">
                 <div>{title}</div>
                 <img src={bgImg} alt={title} className="brightness-75 contrast-125" />

--- a/src/components/EventSection.js
+++ b/src/components/EventSection.js
@@ -3,22 +3,13 @@ import EventCard from "./EventCard";
 
 function EventSection( { title, evenList } ){
     return (
-        <div className="flex justify-center flex-wrap gap-4 w-[1200px] px-4 pb-12 shadow-xl bg-[#242527]">
+        <div className="flex justify-center flex-wrap w-[1200px] px-4 pb-12 shadow-xl bg-[#242527]">
             <div className="w-full py-8">
                 <h1 className="text-center h-12 w-3/4 p-2 ml-auto mr-auto text-white uppercase border-b-2 border-blue-50">{title}</h1>
             </div>
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
-            <EventCard />
+            <div className="flex flex-wrap gap-4 w-[1072px]">
+                {evenList===null?<></>:evenList.map( e => <EventCard event={e} />)}
+            </div>
         </div>
     );
 }

--- a/src/components/EventSection.js
+++ b/src/components/EventSection.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+function EventSection( { title, evenList } ){
+    return (
+        <>
+            <h1 className="text-center text-[#fff] uppercase">{title}</h1>
+        </>
+    );
+}
+
+export default EventSection;

--- a/src/components/EventSection.js
+++ b/src/components/EventSection.js
@@ -1,10 +1,25 @@
 import React from "react";
+import EventCard from "./EventCard";
 
 function EventSection( { title, evenList } ){
     return (
-        <>
-            <h1 className="text-center text-[#fff] uppercase">{title}</h1>
-        </>
+        <div className="flex justify-center flex-wrap gap-4 w-[1200px] px-4 pb-12 shadow-xl bg-[#242527]">
+            <div className="w-full py-8">
+                <h1 className="text-center h-12 w-3/4 p-2 ml-auto mr-auto text-white uppercase border-b-2 border-blue-50">{title}</h1>
+            </div>
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+            <EventCard />
+        </div>
     );
 }
 

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import EventSection from './EventSection';
+
+function Events(){
+    return(
+        <>
+            <EventSection title='Sự kiện sắp diễn ra' />
+            <EventSection title='Sự kiện đang diễn ra' />
+            <EventSection title='Sự kiện đã diễn ra' />
+        </>
+    )
+}
+
+export default Events;

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -1,12 +1,93 @@
 import React from 'react';
 import EventSection from './EventSection';
 
+const upcommingEvents = [
+    {
+        title:'Sự kiện 0',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 1',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 2',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 3',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 4',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 5',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    }
+];
+
+const currentEvents = [
+    {
+        title:'Sự kiện 6',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 7',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+];
+
+const pastEvents = [
+    {
+        title:'Sự kiện 8',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 9',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 10',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+    {
+        title:'Sự kiện 11',
+        ỉmgUrl:'',
+        time:'00:00',
+        date:'19/07/2005'
+    },
+];
+
 function Events(){
     return(
         <>
-            <EventSection title='Sự kiện sắp diễn ra' />
-            <EventSection title='Sự kiện đang diễn ra' />
-            <EventSection title='Sự kiện đã diễn ra' />
+            <EventSection title='Sự kiện sắp diễn ra'   evenList={upcommingEvents}   />
+            <EventSection title='Sự kiện đang diễn ra'  evenList={currentEvents}     />
+            <EventSection title='Sự kiện đã diễn ra'    evenList={pastEvents}        />
         </>
     )
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -18,12 +18,14 @@ const navList = [
 ]
 function Header() {
 	return (
-		<header className="flex justify-between items-center z-10 h-14 px-4 bg-[#242527] border-b-2 border-[#46484b]">
-			<img src={eggIcon} alt='EGG' className='w-12 h-12 rounded-full' />
-			<nav className="flex">
-				{navList.map( navItem => <HeaderNav title={navItem.title} /> )}
-			</nav>
-			<button className="px-4 py-2 border-2 border-black bg-white cursor-pointer">Đăng nhập</button>
+		<header className="fixed top-0 w-full border-b-2 border-[#46484b]">
+			<div className="flex justify-between items-center z-10 h-14 px-4 bg-[#242527]">
+				<img src={eggIcon} alt='EGG' className='w-12 h-12 rounded-full' />
+				<nav className="flex">
+					{navList.map( navItem => <HeaderNav title={navItem.title} /> )}
+				</nav>
+				<button className="px-4 py-2 border-2 border-black bg-white cursor-pointer">Đăng nhập</button>
+			</div>
 		</header>
 	);
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,15 +1,27 @@
 import React from 'react';
 import eggIcon from '../assets/eggIcon.jpg';
 import HeaderNav from './HeaderNav';
-
+	
+const navList = [
+	{
+		title:'Home'
+	},
+	{
+		title:'About EGG'
+	},
+	{
+		title:'Thông tin, sự kiện'
+	},
+	{
+		title:'Humans of EGG'
+	}
+]
 function Header() {
 	return (
 		<header className="flex justify-between items-center z-10 h-14 px-4 bg-[#242527] border-b-2 border-[#46484b]">
 			<img src={eggIcon} alt='EGG' className='w-12 h-12 rounded-full' />
 			<nav className="flex">
-				<HeaderNav title='About EGG'></HeaderNav>
-				<HeaderNav title='Thông tin, sự kiện'></HeaderNav>
-				<HeaderNav title='Humans of EGG'></HeaderNav>
+				{navList.map( navItem => <HeaderNav title={navItem.title} /> )}
 			</nav>
 			<button className="px-4 py-2 border-2 border-black bg-white cursor-pointer">Đăng nhập</button>
 		</header>

--- a/src/components/HeaderNav.js
+++ b/src/components/HeaderNav.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-function HeaderNav( { ref, title } ){
+function HeaderNav( { title, handleClick } ){
     return(
-        <a href={ref} className="text-[#b1b2b6] uppercase hover:cursor-pointer h-12 leading-[48px] px-4">{title}</a>
+        <a href="#" className="text-[#b1b2b6] uppercase hover:cursor-pointer h-12 leading-[48px] px-8" onClick={handleClick}>{title}</a>
     )
 }
 

--- a/src/components/HeaderNav.js
+++ b/src/components/HeaderNav.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 function HeaderNav( { title, handleClick } ){
     return(
-        <a href="#" className="text-[#b1b2b6] uppercase hover:cursor-pointer h-12 leading-[48px] px-8" onClick={handleClick}>{title}</a>
+        <button className="text-[#b1b2b6] uppercase hover:cursor-pointer h-12 leading-[48px] px-8" onClick={handleClick}>{title}</button>
     )
 }
 

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,0 +1,14 @@
+import React from "react";
+import HighlightEvent from './HighlightEvent';
+import HumansOfEgg from './HumansOfEgg';
+
+function Home(){
+    return (
+        <>
+            <HighlightEvent />
+            <HumansOfEgg />
+        </>
+    );
+}
+
+export default Home;


### PR DESCRIPTION
1. Event Page:
Thêm Page Event, EventSection, EventCard
Dữ liệu sự kiện tạm thời để trong component Event.js thành các mảng
Sau sẽ để riêng xong push vào làm props cho từng section
EventCard mới có layout để nhìn, chưa hỗ trợ chức năng bấm hiện thông tin hay hiện modal để join

![image](https://github.com/user-attachments/assets/f5439e8e-f304-490b-98e7-60b3b8bd7a27)

2. Home Page:
Thêm component Home để trang chính, để đảm bảo cấu trúc mỗi page 1 wrapper
Vứt content mặc định trong ContentContainer vô Home
Quên chưa import Home Page vô, nhưng mà lười commit một phát nữa

3. Header:
Thêm điều hướng Home trên HeaderNav
Cố định thanh Header

4. ContentContainer:
Thêm margin bù khoảng trống Header để lại (required)
Chỉnh lại flex-direction về mặc định, thay items-center thành justify-center,  flex-wrap để các thành phần tự động xuống dưới
(optional, sau khi test test vài lần thì tôi thấy k có gì khác nhau lắm đoạn này, nếu mà ông có dụng ý gì khác thì để  như cũ)